### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,22 +51,22 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.0</version>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.17.0</version>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.0</version>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
-      <version>2.17.0</version>
+      <version>2.17.1</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-44832